### PR TITLE
Stringify request body

### DIFF
--- a/src/toggl.ts
+++ b/src/toggl.ts
@@ -64,7 +64,7 @@ export class Toggl {
 		const { data } = await this.axios.request<T>({
 			url,
 			method,
-			data: body,
+			data: JSON.stringify(body),
 			headers: {
 				'Content-Type': 'application/json',
 			},


### PR DESCRIPTION
Even though the [axios documentation](https://axios-http.com/docs/req_config) specifies that plain objects can be passed in the `data` parameter for POST requests is does not seem to work.

```
  // `data` is the data to be sent as the request body
  // Only applicable for request methods 'PUT', 'POST', 'DELETE', and 'PATCH'
  // When no `transformRequest` is set, must be of one of the following types:
  // - string, plain object, ArrayBuffer, ArrayBufferView, URLSearchParams
  // - Browser only: FormData, File, Blob
  // - Node only: Stream, Buffer
  data: {
    firstName: 'Fred'
  },
```