### PR TITLE
Add support for the 'meta' query parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "toggl-track",
-	"version": "0.8.0",
+	"version": "0.8.1-dev",
 	"description": "A TypeScript client for the Toogl Track API (v9)",
 	"keywords": [
 		"toggl",

--- a/src/timeEntry.ts
+++ b/src/timeEntry.ts
@@ -14,6 +14,7 @@ export class TimeEntry {
 		since?: string;
 		startDate?: Date | string;
 		endDate?: Date | string;
+		includeMeta?: boolean;
 	}) {
 		return this.toggl.request<ITimeEntry[]>('me/time_entries', {
 			query: {
@@ -21,6 +22,7 @@ export class TimeEntry {
 				since: query?.since,
 				start_date: query?.startDate?.toString(),
 				end_date: query?.endDate?.toString(),
+				meta: query?.includeMeta ? 'true' : 'false',
 			},
 		});
 	}
@@ -170,6 +172,10 @@ export interface ITimeEntry {
 	user_id: number;
 	wid: number;
 	workspace_id: number;
+	client_name?: string; // NOTE: Only available if includeMeta: true in query.
+	project_name?: string; // NOTE: Only available if includeMeta: true in query.
+	project_color?: string; // NOTE: Only available if includeMeta: true in query.
+	project_active?: boolean; // NOTE: Only available if includeMeta: true in query.
 }
 
 export interface IUpdateBulkResponse {


### PR DESCRIPTION
The parameter has been documented (if poorly) at
https://engineering.toggl.com/docs/api/time_entries#parameters.

This would close #12 .